### PR TITLE
removed (",") from def advance(self, ):

### DIFF
--- a/ep2/basic.py
+++ b/ep2/basic.py
@@ -223,7 +223,7 @@ class Parser:
 		self.tok_idx = -1
 		self.advance()
 
-	def advance(self, ):
+	def advance(self):
 		self.tok_idx += 1
 		if self.tok_idx < len(self.tokens):
 			self.current_tok = self.tokens[self.tok_idx]


### PR DESCRIPTION
Removed (",") from def advance(self, ) in class Parser. It will generate syntax error.